### PR TITLE
Configuration in JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ export PROXMOX_PASSWORD=apiuser1234
 export PROXMOX_INVALID_CERT=False
 ```
 
+You may also save your settings in a JSON file with the same name of the Python script, in its same folder (e.g.: if the downloaded script is `/etc/ansible/proxmox.py`, the configuration file will be `/etc/ansible/proxmox.json`): 
+
+```json
+{
+    "url": "https://10.0.0.1:8006/",
+    "username": "apiuser@pve",
+    "password": "apiuser1234",
+    "validateCert": false
+}
+```
+
 So now you can check it again without credential parameters:
 
 ```sh

--- a/proxmox.json.dist
+++ b/proxmox.json.dist
@@ -1,0 +1,6 @@
+{
+    "url": "https://10.0.0.1:8006/",
+    "username": "apiuser@pve",
+    "password": "apiuser1234",
+    "validateCert": false
+}

--- a/proxmox.py
+++ b/proxmox.py
@@ -89,12 +89,33 @@ class ProxmoxAPI(object):
         self.options = options
         self.credentials = None
 
+        if not options.url or options.username or options.password:
+            config_path = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                os.path.splitext(os.path.basename(__file__))[0]+".json"
+            )
+            if os.path.isfile(config_path):
+                with open(config_path, "r") as config_file:
+                    config_data = json.load(config_file)
+                    try:
+                        options.url = config_data["url"]
+                    except KeyError:
+                        options.url = None
+                    try:
+                        options.username = config_data["username"]
+                    except KeyError:
+                        options.username = None
+                    try:
+                        options.password = config_data["password"]
+                    except KeyError:
+                        options.password = None
+
         if not options.url:
-            raise Exception('Missing mandatory parameter --url (or PROXMOX_URL).')
+            raise Exception('Missing mandatory parameter --url (or PROXMOX_URL or "url" key in config file).')
         elif not options.username:
-            raise Exception('Missing mandatory parameter --username (or PROXMOX_USERNAME).')
+            raise Exception('Missing mandatory parameter --username (or PROXMOX_USERNAME or "username" key in config file).')
         elif not options.password:
-            raise Exception('Missing mandatory parameter --password (or PROXMOX_PASSWORD).')
+            raise Exception('Missing mandatory parameter --password (or PROXMOX_PASSWORD or "password" key in config file).')
 
     def auth(self):
         request_path = '{}api2/json/access/ticket'.format(self.options.url)

--- a/proxmox.py
+++ b/proxmox.py
@@ -94,21 +94,25 @@ class ProxmoxAPI(object):
                 os.path.dirname(os.path.abspath(__file__)),
                 os.path.splitext(os.path.basename(__file__))[0]+".json"
             )
+        if not options.url or not options.username or not options.password:
             if os.path.isfile(config_path):
                 with open(config_path, "r") as config_file:
                     config_data = json.load(config_file)
-                    try:
-                        options.url = config_data["url"]
-                    except KeyError:
-                        options.url = None
-                    try:
-                        options.username = config_data["username"]
-                    except KeyError:
-                        options.username = None
-                    try:
-                        options.password = config_data["password"]
-                    except KeyError:
-                        options.password = None
+                    if not options.url:
+                        try:
+                            options.url = config_data["url"]
+                        except KeyError:
+                            options.url = None
+                    if not options.username:
+                        try:
+                            options.username = config_data["username"]
+                        except KeyError:
+                            options.username = None
+                    if not options.password:
+                        try:
+                            options.password = config_data["password"]
+                        except KeyError:
+                            options.password = None
 
         if not options.url:
             raise Exception('Missing mandatory parameter --url (or PROXMOX_URL or "url" key in config file).')

--- a/proxmox.py
+++ b/proxmox.py
@@ -285,7 +285,7 @@ def main():
         with open(config_path, "r") as config_file:
             config_data = json.load(config_file)
             try:
-                bool_validate_cert = config_data["trustInvalidCerts"]
+                bool_validate_cert = config_data["validateCert"]
             except KeyError:
                 pass
     if os.environ.has_key('PROXMOX_INVALID_CERT'):


### PR DESCRIPTION
I tought that in some deployments it could be useful to have the configuration written in a file rather than sourcing the values from environment variables.

The order of precedence of settings is (topmost takes over bottommost):
+ CLI flags
+ Environment variable
+ Configuration file

---

The JSON config file is searched in the same directory of the Python script, with the same filename but with a `.json` extension. An example file (included in the PR):

```json
{
    "url": "https://10.0.0.1:8006/",
    "username": "apiuser@pve",
    "password": "apiuser1234",
    "validateCert": false
}
```
---

This change came in very handy in my environment, let me know if you want anything done differently or if you're not interested in this at all :)

_I hope I didn't fuck anything up with [the formatting](90d7582), as there was a mix of tabs and spaces in the file._