### PR TITLE
Filter on qemu and lxc resources only

### DIFF
--- a/proxmox.py
+++ b/proxmox.py
@@ -91,7 +91,7 @@ class ProxmoxVersion(dict):
 
 class ProxmoxPool(dict):
     def get_members_name(self):
-        return [member['name'] for member in self['members'] if member['template'] != 1]
+        return [member['name'] for member in self['members'] if (member['type'] == 'qemu' or member['type'] == 'lxc') and member['template'] != 1]
 
 
 class ProxmoxAPI(object):


### PR DESCRIPTION
# SUMMARY
When using proxmox.py as a dynamic inventory for Ansible, only VM and lxc must be included in the output. Other resources such as datastores must be excluded.

# ISSUE TYPE
Bugfix Pull Request

# ADDITIONAL INFORMATION
If a datastore is defined in a pool, the script crashes as the parameter template does not apply to datastore objects.

# VERSION
PVE 5.4.13