### PR TITLE
grab PVE version without revision (ex: 6.0 not 6.0-7)

### DIFF
--- a/proxmox.py
+++ b/proxmox.py
@@ -86,7 +86,7 @@ class ProxmoxPoolList(list):
 
 class ProxmoxVersion(dict):
     def get_version(self):
-        return float(self['version'])
+        return float(self['version'].split('-')[0])
 
 
 class ProxmoxPool(dict):


### PR DESCRIPTION
this avoid error with float()

Resolve #17 