### PR TITLE
Get the IP address automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Resolvable VM names: the inventory script collects the VM names (and not IP addr
 - Handle cases where node is unavailable (@andor44) [#7]
 - Fix python 2 and 3 compatibility (@gardar) [#14]
 - Filter on qemu and lxc resources only (@adubreuiltk) [#16]
+- Get the IP address automatically (@xezpeleta) [#8]
 
 ## Instructions
 

--- a/proxmox.py
+++ b/proxmox.py
@@ -205,17 +205,18 @@ class ProxmoxAPI(object):
         ip_address = None
         networks = self.get('api2/json/nodes/{0}/qemu/{1}/agent/network-get-interfaces'.format(node, vm))['result']
         if networks:
-            for network in networks:
-                for address in network['ip-addresses']:
-                    ip_address = address['ip-address']
-                    try:
-                        # IP address validation
-                        if socket.inet_aton(ip_address):
-                            # Ignore localhost
-                            if ip_address != '127.0.0.1':
-                                return ip_address
-                    except socket.error:
-                        pass
+            if type(network) is dict:
+                for network in networks:
+                    for address in network['ip-addresses']:
+                        ip_address = address['ip-address']
+                        try:
+                            # IP address validation
+                            if socket.inet_aton(ip_address):
+                                # Ignore localhost
+                                if ip_address != '127.0.0.1':
+                                    return ip_address
+                        except socket.error:
+                            pass
         return None
     
     def openvz_ip_address(self, node, vm):

--- a/proxmox.py
+++ b/proxmox.py
@@ -33,6 +33,7 @@ except ImportError:
     import simplejson as json
 import os
 import sys
+import socket
 from optparse import OptionParser
 
 from six import iteritems
@@ -190,7 +191,32 @@ class ProxmoxAPI(object):
 
     def pool(self, poolid):
         return ProxmoxPool(self.get('api2/json/pools/{0}'.format(poolid)))
-
+    
+    def qemu_agent(self, node, vm):
+        try:
+            info = self.get('api2/json/nodes/{0}/qemu/{1}/agent/info'.format(node, vm))
+            if info is not None:
+                return True
+        except HTTPError as error:
+            return False
+    
+    def qemu_ip_address(self, node, vm):
+        ip_address = None
+        networks = self.get('api2/json/nodes/{0}/qemu/{1}/agent/network-get-interfaces'.format(node, vm))['result']
+        if networks:
+            for network in networks:
+                for address in network['ip-addresses']:
+                    ip_address = address['ip-address']
+                    try:
+                        # IP address validation
+                        if socket.inet_aton(ip_address):
+                            # Ignore localhost
+                            if ip_address != '127.0.0.1':
+                                return ip_address
+                    except socket.error:
+                        pass
+        return None
+    
     def version(self):
         return ProxmoxVersion(self.get('api2/json/version'))
 
@@ -255,7 +281,11 @@ def main_list(options, config_path):
                 metadata = {
                     'notes': description
                 }
-
+            
+            # If Qemu Agent is enabled, try to guess the IP address
+            if proxmox_api.qemu_agent(node, vmid):
+                results['_meta']['hostvars'][vm]['ansible_host'] = proxmox_api.qemu_ip_address(node, vmid)
+            
             if 'groups' in metadata:
                 # print metadata
                 for group in metadata['groups']:


### PR DESCRIPTION
Proxmox inventory will try to guess the VM hosts IP address (see #8):
- [x] Support for KVM hosts (requires Qemu Agent enabled)
- [x] Support for LXC containers