### PR TITLE
Fixed python3 errors

### DIFF
--- a/proxmox.py
+++ b/proxmox.py
@@ -205,18 +205,17 @@ class ProxmoxAPI(object):
         ip_address = None
         networks = self.get('api2/json/nodes/{0}/qemu/{1}/agent/network-get-interfaces'.format(node, vm))['result']
         if networks:
-            if type(network) is dict:
+            if type(networks) is dict:
                 for network in networks:
-                    for address in network['ip-addresses']:
-                        ip_address = address['ip-address']
-                        try:
-                            # IP address validation
-                            if socket.inet_aton(ip_address):
-                                # Ignore localhost
-                                if ip_address != '127.0.0.1':
-                                    return ip_address
-                        except socket.error:
-                            pass
+                    for ip_address in ['ip-address']:
+                         try:
+                             # IP address validation
+                             if socket.inet_aton(ip_address):
+                                 # Ignore localhost
+                                 if ip_address != '127.0.0.1':
+                                     return ip_address
+                         except socket.error:
+                             pass
         return None
     
     def openvz_ip_address(self, node, vm):


### PR DESCRIPTION
Modified `network` > `networks`. Also fixed Python3 `TypeError: string indices must be integers` dict error.

Sample output running CentOS 8 with Python3:

```diff
[akhan@boipl03-ansible ansible-linux]$ python3 proxmox.py --url=https://10.10.0.11:8006 --username=root@pam --password=redacted --trust-invalid-certs --list --pretty
{
  "all": {
    "hosts": [
      "boipwh02-gaming",
      "boipwh01-ws2016",
      "boipl03-ansible",
      "boipah01-sophos",
      "boipl-goldimage",
      "boipwh03-win10-util",
      "boipct03-pihole",
      "boipct01-ansible",
      "boipct02-docker",
      "boipct04-dev"
    ]
  },
  "_meta": {
    "hostvars": {
      "boipwh02-gaming": {
        "proxmox_maxmem": 12821987328,
        "proxmox_netin": 22539880315,
        "proxmox_template": "",
        "proxmox_status": "running",
        "proxmox_diskwrite": 0,
        "proxmox_diskread": 0,
        "proxmox_name": "boipwh02-gaming",
        "proxmox_cpu": 0.111373181825876,
        "proxmox_mem": 11838843970,
        "proxmox_maxdisk": 268435456000,
        "proxmox_disk": 0,
        "proxmox_vmid": "105",
        "proxmox_netout": 97103789776,
        "proxmox_pid": "4016",
        "proxmox_uptime": 3124975,
        "proxmox_cpus": 10
      },
      "boipwh01-ws2016": {
        "proxmox_netin": 16356589312,
        "proxmox_status": "running",
        "proxmox_diskread": 0,
        "proxmox_netout": 424212972,
        "proxmox_pid": "3713",
        "proxmox_maxmem": 6442450944,
        "proxmox_cpus": 4,
        "proxmox_diskwrite": 0,
        "proxmox_mem": 5759728587,
        "proxmox_uptime": 1055759,
        "proxmox_name": "boipwh01-ws2016",
        "proxmox_vmid": "101",
        "proxmox_cpu": 0.0147436191266612,
        "proxmox_template": "",
        "proxmox_maxdisk": 34359738368,
        "proxmox_disk": 0,
        "ansible_host": null
      },
      "boipl03-ansible": {
        "proxmox_template": "",
        "proxmox_maxdisk": 53687091200,
        "proxmox_disk": 0,
        "proxmox_cpu": 0.0263128700572116,
        "proxmox_vmid": "108",
        "proxmox_uptime": 111613,
        "proxmox_mem": 3575613233,
        "proxmox_name": "boipl03-ansible",
        "proxmox_diskwrite": 0,
        "proxmox_maxmem": 4294967296,
        "proxmox_cpus": 2,
        "proxmox_diskread": 0,
        "proxmox_netout": 88128200,
        "proxmox_pid": "1842",
        "proxmox_status": "running",
        "proxmox_netin": 323893574
      },
      "boipah01-sophos": {
        "proxmox_netin": 540261673669,
        "proxmox_status": "running",
        "proxmox_maxmem": 6438256640,
        "proxmox_cpus": 4,
        "proxmox_diskread": 0,
        "proxmox_netout": 543281371734,
        "proxmox_pid": "2935",
        "proxmox_name": "boipah01-sophos",
        "proxmox_mem": 5574354367,
        "proxmox_uptime": 1055765,
        "proxmox_diskwrite": 0,
        "proxmox_cpu": 0.0435503859761405,
        "proxmox_vmid": "107",
        "proxmox_template": "",
        "proxmox_disk": 0,
        "proxmox_maxdisk": 34359738368
      },
      "boipl-goldimage": {
        "proxmox_diskread": 0,
        "proxmox_netout": 0,
        "proxmox_pid": null,
        "proxmox_maxmem": 4294967296,
        "proxmox_cpus": 2,
        "proxmox_status": "stopped",
        "proxmox_netin": 0,
        "proxmox_template": "",
        "proxmox_disk": 0,
        "proxmox_maxdisk": 53687091200,
        "proxmox_vmid": "109",
        "proxmox_cpu": 0,
        "proxmox_diskwrite": 0,
        "proxmox_mem": 0,
        "proxmox_name": "boipl-goldimage",
        "proxmox_uptime": 0
      },
      "boipwh03-win10-util": {
        "proxmox_disk": 0,
        "proxmox_maxdisk": 52613349376,
        "proxmox_template": "",
        "proxmox_vmid": "104",
        "proxmox_cpu": 0.020534706024378,
        "proxmox_diskwrite": 0,
        "proxmox_mem": 3503961161,
        "proxmox_uptime": 1055741,
        "proxmox_name": "boipwh03-win10-util",
        "proxmox_pid": "5460",
        "proxmox_diskread": 0,
        "proxmox_netout": 7926140634,
        "proxmox_cpus": 4,
        "proxmox_maxmem": 4194304000,
        "proxmox_status": "running",
        "proxmox_netin": 9079006987
      },
      "boipct03-pihole": {
        "proxmox_maxmem": 4294967296,
        "proxmox_cpus": 4,
        "proxmox_pid": "4567",
        "proxmox_netout": 139285812,
        "proxmox_diskread": 1782788096,
        "proxmox_swap": 204800,
        "proxmox_netin": 769840041,
        "proxmox_type": "lxc",
        "proxmox_status": "running",
        "proxmox_lock": "",
        "proxmox_disk": "1855848448",
        "proxmox_maxdisk": "21003583488",
        "proxmox_template": "",
        "proxmox_maxswap": 536870912,
        "proxmox_uptime": 1055752,
        "proxmox_name": "boipct03-pihole",
        "proxmox_mem": 50520064,
        "proxmox_diskwrite": 12550107136,
        "proxmox_cpu": 0.000145231412841471,
        "proxmox_vmid": "103",
        "ansible_host": "10.10.0.80"
      },
      "boipct01-ansible": {
        "proxmox_lock": "",
        "proxmox_status": "running",
        "proxmox_swap": 4096,
        "proxmox_netin": 81329853,
        "proxmox_type": "lxc",
        "proxmox_cpus": 1,
        "proxmox_maxmem": 2147483648,
        "proxmox_diskread": 663760896,
        "proxmox_netout": 4722410,
        "proxmox_pid": "13763",
        "proxmox_cpu": 5.2811422851444e-05,
        "proxmox_vmid": "102",
        "proxmox_name": "boipct01-ansible",
        "proxmox_uptime": 97039,
        "proxmox_mem": 20766720,
        "proxmox_diskwrite": 335679488,
        "proxmox_template": "",
        "proxmox_maxswap": 536870912,
        "proxmox_disk": "977174528",
        "proxmox_maxdisk": "10501771264",
        "ansible_host": "10.10.0.76"
      },
      "boipct02-docker": {
        "proxmox_template": "",
        "proxmox_maxswap": 0,
        "proxmox_maxdisk": "115422527488",
        "proxmox_disk": "96239091712",
        "proxmox_diskwrite": 0,
        "proxmox_name": "boipct02-docker",
        "proxmox_uptime": 1055736,
        "proxmox_mem": 2384936960,
        "proxmox_vmid": "106",
        "proxmox_cpu": 0.0129238353621292,
        "proxmox_diskread": 24576,
        "proxmox_netout": 118758823489,
        "proxmox_pid": "5857",
        "proxmox_cpus": 24,
        "proxmox_maxmem": 10485760000,
        "proxmox_type": "lxc",
        "proxmox_netin": 133447008921,
        "proxmox_swap": 59473920,
        "proxmox_lock": "backup",
        "proxmox_status": "running",
        "ansible_host": "10.10.0.81"
      },
      "boipct04-dev": {
        "proxmox_disk": "852725760",
        "proxmox_maxdisk": "21003583488",
        "proxmox_template": "",
        "proxmox_maxswap": 536870912,
        "proxmox_cpu": 0.000839701623337959,
        "proxmox_vmid": "100",
        "proxmox_name": "boipct04-dev",
        "proxmox_uptime": 1055747,
        "proxmox_mem": 31043584,
        "proxmox_diskwrite": 107085824,
        "proxmox_cpus": 2,
        "proxmox_maxmem": 4194304000,
        "proxmox_pid": "4968",
        "proxmox_diskread": 669659136,
        "proxmox_netout": 2327008561,
        "proxmox_status": "running",
        "proxmox_lock": "",
        "proxmox_swap": 98304,
        "proxmox_netin": 2965826600,
        "proxmox_type": "lxc",
        "ansible_host": false
      }
    }
  },
  "running": {
    "hosts": [
      "boipwh02-gaming",
      "boipwh01-ws2016",
      "boipl03-ansible",
      "boipah01-sophos",
      "boipwh03-win10-util",
      "boipct03-pihole",
      "boipct01-ansible",
      "boipct02-docker",
      "boipct04-dev"
    ]
  }
}
```