### PR TITLE
Fix QEMU guest agent IP address retrieval

### DIFF
--- a/proxmox.py
+++ b/proxmox.py
@@ -216,6 +216,17 @@ class ProxmoxAPI(object):
                                      return ip_address
                          except socket.error:
                              pass
+            elif type(networks) is list:
+                for network in networks:
+                    for ip_address in network['ip-addresses']:
+                         try:
+                             # IP address validation
+                             if socket.inet_aton(ip_address['ip-address']):
+                                 # Ignore localhost
+                                 if ip_address['ip-address'] != '127.0.0.1':
+                                     return ip_address['ip-address']
+                         except socket.error:
+                             pass
         return None
     
     def openvz_ip_address(self, node, vm):

--- a/proxmox.py
+++ b/proxmox.py
@@ -208,25 +208,26 @@ class ProxmoxAPI(object):
             if type(networks) is dict:
                 for network in networks:
                     for ip_address in ['ip-address']:
-                         try:
-                             # IP address validation
-                             if socket.inet_aton(ip_address):
-                                 # Ignore localhost
-                                 if ip_address != '127.0.0.1':
-                                     return ip_address
-                         except socket.error:
-                             pass
+                        try:
+                            # IP address validation
+                            if socket.inet_aton(ip_address):
+                                # Ignore localhost
+                                if ip_address != '127.0.0.1':
+                                    return ip_address
+                        except socket.error:
+                            pass
             elif type(networks) is list:
                 for network in networks:
-                    for ip_address in network['ip-addresses']:
-                         try:
-                             # IP address validation
-                             if socket.inet_aton(ip_address['ip-address']):
-                                 # Ignore localhost
-                                 if ip_address['ip-address'] != '127.0.0.1':
-                                     return ip_address['ip-address']
-                         except socket.error:
-                             pass
+                    if 'ip-addresses' in network:
+                        for ip_address in network['ip-addresses']:
+                            try:
+                                # IP address validation
+                                if socket.inet_aton(ip_address['ip-address']):
+                                    # Ignore localhost
+                                    if ip_address['ip-address'] != '127.0.0.1':
+                                        return ip_address['ip-address']
+                            except socket.error:
+                                pass
         return None
     
     def openvz_ip_address(self, node, vm):


### PR DESCRIPTION
This adds the fix from #27 by @marcelohuqu. I'm not sure if there was an older version of the Proxmox API where `networks` was a `dict`, so I left it in and added the `list` version below. Proxmox 6.2 has `networks` as a list.