### PR TITLE
Check if "template" key exists in Proxmox API result

### DIFF
--- a/proxmox.py
+++ b/proxmox.py
@@ -65,7 +65,7 @@ class ProxmoxVMList(list):
 
     def get_names(self):
         if self.ver >= 4.0:
-            return [vm['name'] for vm in self if vm['template'] != 1]
+            return [vm['name'] for vm in self if 'template' in vm and vm['template'] != 1]
         else:
             return [vm['name'] for vm in self]
 


### PR DESCRIPTION
Opening this PR to fix the issue on Proxmox upgraded to version 7.0
It seems that the result of `api2/json/nodes/<nodnemae>/qemu` doesn't contain the `template` key anymore.