### PR TITLE
Hostname as ansible_host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.0.3
+
+- Added function to take "hostname" as ansible_hostname from API if LXC uses DHCP-leases
 
 ## v1.0.2
 - Proxmox v7 compatibility check if template key exists (by @maynero) [#39](https://github.com/xezpeleta/Ansible-Proxmox-inventory/pull/39)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ansible-Proxmox-inventory
+## FORK
 
+This fork applied a patch , which uses the CT Name as ansible_host. So you can use DHCP-assingments. (FQDN needs to be resolvable by ansible) 
 ## About
 
 Proxmox dynamic inventory for Ansible. Based on [original plugin](https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/proxmox.py) from Mathieu Gauthier-Lafaye
@@ -10,7 +12,8 @@ It will generate an inventory on the fly with all your VMs stored in your Proxmo
 
 ### Requirements
 
-Resolvable VM names: the inventory script collects the VM names (and not IP addresses!). That's why your computer must be able to resolve these names; either with the DNS server or your */etc/hosts* 
+Resolvable VM AND CT names: the inventory script collects the VM/CT names (and not IP addresses!). 
+That's why your computer must be able to resolve these names; either with the DNS server or your */etc/hosts* 
 
 
 ### Features

--- a/proxmox.py
+++ b/proxmox.py
@@ -363,7 +363,7 @@ def main_list(options, config_path):
                     results['_meta']['hostvars'][vm]['proxmox_os_version_id'] = system_info.version_id
             else:
              # IF IP is empty (due DHCP, take hostname instead)
-                if proxmox_api.openvz_ip_address(node, vm) == False:
+                if proxmox_api.openvz_ip_address(node, vm) != False:
                     results['_meta']['hostvars'][vm]['ansible_host'] = proxmox_api.openvz_ip_address(node, vmid)
                 else:
                     results['_meta']['hostvars'][vm]['ansible_host'] = proxmox_api.lxc_hostname(node, vmid)

--- a/proxmox.py
+++ b/proxmox.py
@@ -129,7 +129,7 @@ class ProxmoxAPI(object):
         elif not options.password:
             raise Exception(
                 'Missing mandatory parameter --password (or PROXMOX_PASSWORD or "password" key in config file).')
-        
+
         # URL should end with a trailing slash
         if not options.url.endswith("/"):
             options.url = options.url + "/"
@@ -210,6 +210,21 @@ class ProxmoxAPI(object):
         try:
             ip_address = re.search('ip=(\d*\.\d*\.\d*\.\d*)', config['net0']).group(1)
             return ip_address
+        except:
+            return False
+
+### PATCH for LXC HOSTNAME 
+### GET HOSTNAME for LXC-Containers
+
+    def lxc_hostname(self, node, vm):
+        try:
+            config = self.get('api2/json/nodes/{0}/lxc/{1}/config'.format(node, vm))
+        except HTTPError:
+            return False
+        
+        try:
+            hostname = config['hostname']
+            return hostname
         except:
             return False
     
@@ -347,8 +362,12 @@ def main_list(options, config_path):
                     results['_meta']['hostvars'][vm]['proxmox_os_kernel'] = system_info.kernel
                     results['_meta']['hostvars'][vm]['proxmox_os_version_id'] = system_info.version_id
             else:
-                results['_meta']['hostvars'][vm]['ansible_host'] = proxmox_api.openvz_ip_address(node, vmid)
-            
+             # IF IP is empty (due DHCP, take hostname instead)
+                if proxmox_api.openvz_ip_address(node, vm) == False:
+                    results['_meta']['hostvars'][vm]['ansible_host'] = proxmox_api.openvz_ip_address(node, vmid)
+                else:
+                    results['_meta']['hostvars'][vm]['ansible_host'] = proxmox_api.lxc_hostname(node, vmid)
+
             if 'groups' in metadata:
                 # print metadata
                 for group in metadata['groups']:


### PR DESCRIPTION
Added API-Call to use the hostname as ansible_host when no static IP is configured at the LXC-container