### PR TITLE
Kubernetes and wirguard fix

### DIFF
--- a/proxmox.py
+++ b/proxmox.py
@@ -247,7 +247,9 @@ class ProxmoxAPI(object):
                                 # Ignore localhost and docker IPs
                                 if (ip_address != '127.0.0.1' and # Ignore localhost
                                     "02:42" not in network["hardware-address"] and # Ingore Docker Interfaces
-                                    "veth" not in network["name"]): # Ignore virtual ethernet ports
+                                    "veth" not in network["name"] and # Ignore virtual ethernet ports
+                                    "flannel" not in network["name"] and # Ignore virtual ethernet ports
+                                    "cali" not in network["name"]): # Ignore virtual ethernet ports
                                     system_info.ip_address = ip_address
                         except socket.error:
                             pass
@@ -261,8 +263,9 @@ class ProxmoxAPI(object):
                                     
                                     if (ip_address['ip-address'] != '127.0.0.1' and # Ignore localhost
                                        "02:42" not in network["hardware-address"] and # Ingore Docker Interfaces
-                                       "veth" not in network["name"]): # Ignore virtual ethernet ports
-
+                                       "veth" not in network["name"] and # Ignore virtual ethernet ports
+                                       "flannel" not in network["name"] and # Ignore virtual ethernet ports
+                                       "cali" not in network["name"]): # Ignore virtual ethernet ports
                                         system_info.ip_address = ip_address['ip-address']
                             except socket.error:
                                 pass

--- a/proxmox.py
+++ b/proxmox.py
@@ -244,8 +244,10 @@ class ProxmoxAPI(object):
                         try:
                             # IP address validation
                             if socket.inet_aton(ip_address):
-                                # Ignore localhost
-                                if ip_address != '127.0.0.1':
+                                # Ignore localhost and docker IPs
+                                if (ip_address != '127.0.0.1' and # Ignore localhost
+                                    "02:42" not in network["hardware-address"] and # Ingore Docker Interfaces
+                                    "veth" not in network["name"]): # Ignore virtual ethernet ports
                                     system_info.ip_address = ip_address
                         except socket.error:
                             pass
@@ -256,8 +258,11 @@ class ProxmoxAPI(object):
                             try:
                                 # IP address validation
                                 if socket.inet_aton(ip_address['ip-address']):
-                                    # Ignore localhost
-                                    if ip_address['ip-address'] != '127.0.0.1':
+                                    
+                                    if (ip_address['ip-address'] != '127.0.0.1' and # Ignore localhost
+                                       "02:42" not in network["hardware-address"] and # Ingore Docker Interfaces
+                                       "veth" not in network["name"]): # Ignore virtual ethernet ports
+
                                         system_info.ip_address = ip_address['ip-address']
                             except socket.error:
                                 pass

--- a/proxmox.py
+++ b/proxmox.py
@@ -247,8 +247,8 @@ class ProxmoxAPI(object):
                                 # Ignore localhost, docker, kubernetes IPs
                                 if (ip_address != '127.0.0.1' and # Ignore localhost
                                     "02:42" not in network["hardware-address"] and # Ingore Docker Interfaces
-                                    "veth" not in network["name"]) and # Ignore virtual ethernet ports
-                                    "flannel" not in network["name"]) and # Ignore virtual ethernet ports
+                                    "veth" not in network["name"]): and # Ignore virtual ethernet ports
+                                    "flannel" not in network["name"]): and # Ignore virtual ethernet ports
                                     "calico" not in network["name"]):  # Ignore virtual ethernet ports
                                     system_info.ip_address = ip_address
                         except socket.error:
@@ -264,7 +264,8 @@ class ProxmoxAPI(object):
                                     if (ip_address['ip-address'] != '127.0.0.1' and # Ignore localhost
                                        "02:42" not in network["hardware-address"] and # Ingore Docker Interfaces
                                        "veth" not in network["name"]): # Ignore virtual ethernet ports
-
+                                       "flannel" not in network["name"]): and # Ignore virtual ethernet ports
+                                       "calico" not in network["name"]):  # Ignore virtual ethernet ports
                                         system_info.ip_address = ip_address['ip-address']
                             except socket.error:
                                 pass

--- a/proxmox.py
+++ b/proxmox.py
@@ -244,10 +244,12 @@ class ProxmoxAPI(object):
                         try:
                             # IP address validation
                             if socket.inet_aton(ip_address):
-                                # Ignore localhost and docker IPs
+                                # Ignore localhost, docker, kubernetes IPs
                                 if (ip_address != '127.0.0.1' and # Ignore localhost
                                     "02:42" not in network["hardware-address"] and # Ingore Docker Interfaces
-                                    "veth" not in network["name"]): # Ignore virtual ethernet ports
+                                    "veth" not in network["name"]): and # Ignore virtual ethernet ports
+                                    "flannel" not in network["name"]): and # Ignore virtual ethernet ports
+                                    "calico" not in network["name"]):  # Ignore virtual ethernet ports
                                     system_info.ip_address = ip_address
                         except socket.error:
                             pass

--- a/proxmox.py
+++ b/proxmox.py
@@ -247,8 +247,8 @@ class ProxmoxAPI(object):
                                 # Ignore localhost, docker, kubernetes IPs
                                 if (ip_address != '127.0.0.1' and # Ignore localhost
                                     "02:42" not in network["hardware-address"] and # Ingore Docker Interfaces
-                                    "veth" not in network["name"]): and # Ignore virtual ethernet ports
-                                    "flannel" not in network["name"]): and # Ignore virtual ethernet ports
+                                    "veth" not in network["name"]) and # Ignore virtual ethernet ports
+                                    "flannel" not in network["name"]) and # Ignore virtual ethernet ports
                                     "calico" not in network["name"]):  # Ignore virtual ethernet ports
                                     system_info.ip_address = ip_address
                         except socket.error:

--- a/proxmox.py
+++ b/proxmox.py
@@ -248,8 +248,9 @@ class ProxmoxAPI(object):
                                 if (ip_address != '127.0.0.1' and # Ignore localhost
                                     "02:42" not in network["hardware-address"] and # Ingore Docker Interfaces
                                     "veth" not in network["name"] and # Ignore virtual ethernet ports
-                                    "flannel" not in network["name"] and # Ignore virtual ethernet ports
-                                    "cali" not in network["name"]): # Ignore virtual ethernet ports
+                                    "flannel" not in network["name"] and # Ignore flannel k8s network
+                                    "cali" not in network["name"] and # Ignore calico k8s network
+                                    "wg" not in network["name"]): # Ignore wireguard network
                                     system_info.ip_address = ip_address
                         except socket.error:
                             pass
@@ -264,8 +265,9 @@ class ProxmoxAPI(object):
                                     if (ip_address['ip-address'] != '127.0.0.1' and # Ignore localhost
                                        "02:42" not in network["hardware-address"] and # Ingore Docker Interfaces
                                        "veth" not in network["name"] and # Ignore virtual ethernet ports
-                                       "flannel" not in network["name"] and # Ignore virtual ethernet ports
-                                       "cali" not in network["name"]): # Ignore virtual ethernet ports
+                                       "flannel" not in network["name"] and # Ignore flannel k8s network
+                                       "cali" not in network["name"] # Ignore calico k8s network
+                                       "wg" not in network["name"]): # Ignore wireguard network
                                         system_info.ip_address = ip_address['ip-address']
                             except socket.error:
                                 pass

--- a/proxmox.py
+++ b/proxmox.py
@@ -266,7 +266,7 @@ class ProxmoxAPI(object):
                                        "02:42" not in network["hardware-address"] and # Ingore Docker Interfaces
                                        "veth" not in network["name"] and # Ignore virtual ethernet ports
                                        "flannel" not in network["name"] and # Ignore flannel k8s network
-                                       "cali" not in network["name"] # Ignore calico k8s network
+                                       "cali" not in network["name"] and # Ignore calico k8s network
                                        "wg" not in network["name"]): # Ignore wireguard network
                                         system_info.ip_address = ip_address['ip-address']
                             except socket.error:


### PR DESCRIPTION
This adds a filter for kubernetes (calico/flannel) and wireguard interfaces for ignoring them. Only the host interface which we want to connect for ansible will be used. 