### PR TITLE
Added feature to create groups based on tags

### DIFF
--- a/proxmox.py
+++ b/proxmox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2014  Mathieu GAUTHIER-LAFAYE <gauthierl@lapth.cnrs.fr>
 #
@@ -443,7 +443,7 @@ def split_tags(proxmox_tags: str) -> list[str]:
     """
     Splits proxmox_tags delimited by comma and returns a list of the tags.
     """
-    tags = proxmox_tags.split(',')
+    tags = proxmox_tags.split(';')
     return tags
 
 def main_host(options, config_path):

--- a/proxmox.py
+++ b/proxmox.py
@@ -415,6 +415,21 @@ def main_list(options, config_path):
                         }
                     results[osid]['hosts'] += [vm]
 
+            # Create group 'based on proxmox_tags'
+            # so you can: --limit 'worker,external-datastore'
+            try:
+                tags = results['_meta']['hostvars'][vm]['proxmox_tags']
+                vm_name = results['_meta']['hostvars'][vm]['proxmox_name']
+                tag_list = split_tags(tags)
+                for i in range(len(tag_list)):
+                    if tag_list[i] not in results:
+                        results[tag_list[i]] = {
+                            'hosts': []
+                        }
+                    results[tag_list[i]]['hosts'] += [vm]
+            except KeyError:
+                pass
+           
             results['_meta']['hostvars'][vm].update(metadata)
 
     # pools
@@ -422,9 +437,14 @@ def main_list(options, config_path):
         results[pool] = {
             'hosts': proxmox_api.pool(pool).get_members_name(),
         }
-
     return results
 
+def split_tags(proxmox_tags: str) -> list[str]:
+    """
+    Splits proxmox_tags delimited by comma and returns a list of the tags.
+    """
+    tags = proxmox_tags.split(',')
+    return tags
 
 def main_host(options, config_path):
     proxmox_api = ProxmoxAPI(options, config_path)
@@ -479,7 +499,7 @@ def main():
     indent = None
     if options.pretty:
         indent = 2
-
+#TODO
     print((json.dumps(data, indent=indent)))
 
 


### PR DESCRIPTION
### Create groups based on proxmox_tags
- split_tags function added to create a list of tags from proxmox_tags variable declared in inventory
- tries to solve #48 

### Tested on:
- Proxmox Virtual Environment 7.3-3

### Usage:
- populate a static inventory (with hostvars and groupvars) attached - [inventory.yaml](https://github.com/xezpeleta/Ansible-Proxmox-inventory/files/10832234/inventory.yaml.txt), snippet:


```  
...
  children:
    external-datastore:
      vars:
        tags: "external-datastore,k3s-db"
      hosts:
        k3s-db-01.home.xxxxx.com:
    k3s-server:
      vars:
        tags: "controlplane,k3s-server"
      hosts:
        k3s-server-01.home.xxxxx.com:
...
```
- apply tags to VMs - [tag-task.yaml.txt](https://github.com/xezpeleta/Ansible-Proxmox-inventory/files/10832390/tag-task.yaml.txt)
- run dynamic inventory script / ansible-inventory - `ansible-inventory -i Ansible-Proxmox-inventory/proxmox.py --graph` 

```
@all:
  |--@backup:
  |  |--openmediavault
  |  |--proxmox-backup-server
  |--@controlplane:
  |  |--k3s-server-01
  |--@external-datastore:
  |  |--k3s-db-01
  |--@fw:
  |  |--firewall
  |--@k3s-agent:
  |  |--k3s-agent-01.xxxxxxxx.com
  |  |--k3s-agent-02.xxxxxxxx.com
  |  |--k3s-agent-03.xxxxxxxx.com
  |--@k3s-db:
  |  |--k3s-db-01
  |--@k3s-server:
  |  |--k3s-server-01
  |--@running:
  |  |--firewall
  |  |--openmediavault
  |  |--proxmox-backup-server
  |--@ungrouped:
  |--@worker:
  |  |--k3s-agent-01.xxxxxxxx.com
  |  |--k3s-agent-02.xxxxxxxx.com
  |  |--k3s-agent-03.xxxxxxxx.com
```

### Tests and validation:
- tested on empty tags `tag1,tag2,,,,,` and tags with special characters `k3s-server!asdasd!a1213123`
- proxmox validates the tags provided, an invalid tag produces the error:
```
TASK [Apply tags to vms] *****************************************************************************************************************************************************************************************
failed: [proxmox.home.xxxxx.com] (item=k3s-db-01.home.xxxxx.com) => {"ansible_loop_var": "item", "changed": false, "item": "k3s-db-01.home.xxxxx.com", "msg": " **is not a valid tag**"}
changed: [proxmox.home.xxxxx.com] => (item=k3s-agent-01.home.xxxxx.com)
changed: [proxmox.home.xxxxx.com] => (item=k3s-agent-02.home.xxxxx.com)
changed: [proxmox.home.xxxxx.com] => (item=k3s-agent-03.home.xxxxx.com)
failed: [proxmox.home.xxxxx.com] (item=k3s-server-01.home.xxxxx.com) => {"ansible_loop_var": "item", "changed": false, "item": "k3s-server-01.home.xxxxx.com", "msg": "**k3s-server!asdasd!a1213123 is not a valid tag**"}
```

